### PR TITLE
add secrets manager as a source for configuration values

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,10 @@
    [cheshire "5.8.1"]                   ; JSON encoding
    [clj-http "3.9.1"]                   ; HTTP client
    [com.amazonaws/aws-lambda-java-core "1.0.0"]
+   [com.amazonaws/aws-java-sdk-secretsmanager "1.12.118"]
+   [com.fasterxml.jackson.core/jackson-core "2.12.3"]
+   [com.fasterxml.jackson.core/jackson-databind "2.12.3"]
+   [com.fasterxml.jackson.core/jackson-annotations "2.12.3"]
    #_[http-kit "2.3.0"]]
 
   :main ^:skip-aot cla-bot.core

--- a/src/cla_bot/config/aws.clj
+++ b/src/cla_bot/config/aws.clj
@@ -1,0 +1,25 @@
+(ns cla-bot.config.aws
+    (:require [cheshire.core :as json])
+  (:import (com.amazonaws.services.secretsmanager AWSSecretsManagerClientBuilder)
+           (com.amazonaws.services.secretsmanager.model GetSecretValueRequest)))
+
+(def secret-cache (atom nil))
+
+(defn get-secret-value [secret-id]
+  (let [client (AWSSecretsManagerClientBuilder/defaultClient)
+        request (doto (GetSecretValueRequest.)
+                  (.withSecretId secret-id))
+        response (.getSecretValue client request)
+        secret-string (.getSecretString response)]
+    (json/parse-string secret-string true)))
+
+(defn fetch-secret [key]
+  (let [secret-name (System/getenv "SECRET_NAME")]
+    (if secret-name
+      (let [cached-secret @secret-cache]
+        (if cached-secret
+          (get cached-secret (keyword key))
+          (let [secret (get-secret-value secret-name)]
+            (reset! secret-cache secret)
+            (get secret (keyword key)))))
+      nil)))

--- a/src/cla_bot/config/util.clj
+++ b/src/cla_bot/config/util.clj
@@ -12,9 +12,9 @@
 
 (defonce ^:dynamic ^{:doc "List of sources to look for (in order) for configuration values. You can change this value
   to change where config values may be resolved from; for example, if you define a new source, you can add it to the
-    list of places to check here."}
-    *sources*
-    (atom [:env :secretsmanager]))
+  list of places to check here."}
+  *sources*
+  (atom [:env :secretsmanager]))
 
 
 (defmulti parse

--- a/src/cla_bot/config/util.clj
+++ b/src/cla_bot/config/util.clj
@@ -1,6 +1,7 @@
 (ns cla-bot.config.util
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [cla-bot.config.aws :refer [fetch-secret]])
   (:import java.text.NumberFormat))
 
 ;; Overcomplicated! But I wanted to experiment with some ideas I had that might make it into Metabase core.
@@ -11,9 +12,9 @@
 
 (defonce ^:dynamic ^{:doc "List of sources to look for (in order) for configuration values. You can change this value
   to change where config values may be resolved from; for example, if you define a new source, you can add it to the
-  list of places to check here."}
-  *sources*
-  (atom [:env]))
+    list of places to check here."}
+    *sources*
+    (atom [:env :secretsmanager]))
 
 
 (defmulti parse
@@ -62,6 +63,12 @@
 ;; Fetch value from environment variable -- the only default source
 (defmethod value :env [_ k klass not-found]
   (if-let [v (System/getenv (config-env-var k))]
+    (parse klass v)
+    not-found))
+
+;; Fetch value from AWS Secrets Manager
+(defmethod value :secretsmanager [_ k klass not-found]
+  (if-let [v (fetch-secret (config-env-var k))]
     (parse klass v)
     not-found))
 


### PR DESCRIPTION
To address [pen testing](https://github.com/metabase/metabase-ops/issues/1225) we needed to update Lambdas to use Secrets Manager. This adds the ability to specify config values from Secrets Manager.